### PR TITLE
Bumping up kafka and zookeeper versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Allows you to start and stop a Kafka broker + ZooKeeper instance for unit testing applications that communicate with Kafka.
 
-It uses Kafka version ```0.8.0``` and ZooKeeper version ```3.4.5```
+It uses Kafka version ```0.8.2.1``` and ZooKeeper version ```3.4.6```
 
 ## Starting manually
 

--- a/build.gradle
+++ b/build.gradle
@@ -96,14 +96,14 @@ repositories {
 
 dependencies {
     compile 'junit:junit:4.11'
-    compile('org.apache.kafka:kafka_2.10:0.8.0') {
+    compile('org.apache.kafka:kafka_2.11:0.8.2.1') {
         exclude module: 'slf4j-simple'
         exclude module: 'slf4j-log4j12'
         exclude module: 'jmxtools'
         exclude module: 'jmxri'
         exclude module: 'jms'
     }
-    compile('org.apache.zookeeper:zookeeper:3.4.5') {
+    compile('org.apache.zookeeper:zookeeper:3.4.6') {
         exclude module: 'slf4j-log4j12'
         exclude module: 'log4j'
     }

--- a/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnit.java
@@ -1,6 +1,6 @@
 package info.batey.kafka.unit;
 
-import kafka.admin.CreateTopicCommand;
+import kafka.admin.TopicCommand;
 import kafka.consumer.Consumer;
 import kafka.consumer.ConsumerConfig;
 import kafka.consumer.ConsumerIterator;
@@ -66,17 +66,18 @@ public class KafkaUnit {
     }
 
     public void createTopic(String topicName) {
-        String[] arguments = new String[8];
-        arguments[0] = "--zookeeper";
-        arguments[1] = zookeeperString;
-        arguments[2] = "--replica";
-        arguments[3] = "1";
-        arguments[4] = "--partition";
-        arguments[5] = "1";
-        arguments[6] = "--topic";
-        arguments[7] = topicName;
+        String[] arguments = new String[9];
+        arguments[0] = "--create";
+        arguments[1] = "--zookeeper";
+        arguments[2] = zookeeperString;
+        arguments[3] = "--replication-factor";
+        arguments[4] = "1";
+        arguments[5] = "--partitions";
+        arguments[6] = "1";
+        arguments[7] = "--topic";
+        arguments[8] = topicName;
         LOGGER.info("Executing: CreateTopic " + Arrays.toString(arguments));
-        CreateTopicCommand.main(arguments);
+        TopicCommand.main(arguments);
     }
 
 


### PR DESCRIPTION
Gradle is unable to resolve transitive dependencies on Kafka 0.8.0, as you can see in [here](https://issues.apache.org/jira/browse/KAFKA-1064).

This issue has been fixed since, so that's why we created this PR.