### PR TITLE
Producers memory bloat / connections leak

### DIFF
--- a/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnit.java
@@ -33,6 +33,7 @@ public class KafkaUnit {
     private final String brokerString;
     private int zkPort;
     private int brokerPort;
+    private Producer<String, String> producer = null;
 
     public KafkaUnit(int zkPort, int brokerPort) {
         this.zkPort = zkPort;
@@ -128,11 +129,13 @@ public class KafkaUnit {
 
     @SafeVarargs
     public final void sendMessages(KeyedMessage<String, String> message, KeyedMessage<String, String>... messages) {
-        Properties props = new Properties();
-        props.put("serializer.class", StringEncoder.class.getName());
-        props.put("metadata.broker.list", brokerString);
-        ProducerConfig config = new ProducerConfig(props);
-        Producer<String, String> producer = new Producer<>(config);
+        if (producer == null) {
+            Properties props = new Properties();
+            props.put("serializer.class", StringEncoder.class.getName());
+            props.put("metadata.broker.list", brokerString);
+            ProducerConfig config = new ProducerConfig(props);
+            producer = new Producer<>(config);
+        }
         producer.send(message);
         producer.send(Arrays.asList(messages));
 

--- a/src/test/java/info/batey/kafka/unit/KafkaIntegrationTest.java
+++ b/src/test/java/info/batey/kafka/unit/KafkaIntegrationTest.java
@@ -18,11 +18,14 @@ public class KafkaIntegrationTest {
     @Before
     public void setUp() throws Exception {
         kafkaUnitServer = new KafkaUnit(5000, 5001);
+        kafkaUnitServer.setKafkaBrokerConfig("log.segment.bytes", "1024");
         kafkaUnitServer.startup();
     }
 
     @After
     public void shutdown() throws Exception {
+        assert kafkaUnitServer.broker.serverConfig().logSegmentBytes() == 1024;
+
         kafkaUnitServer.shutdown();
     }
 


### PR DESCRIPTION
If you wanna send thousand messages using KafkaUnit.sendMessages() you'll run into connections leak.
This fix creates the producer lazily.