### PR TITLE
Privatise the kafka broker

### DIFF
--- a/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnit.java
@@ -45,7 +45,7 @@ public class KafkaUnit {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaUnit.class);
 
-    public KafkaServerStartable broker;
+    private KafkaServerStartable broker;
 
     private Zookeeper zookeeper;
     private final String zookeeperString;

--- a/src/test/java/info/batey/kafka/unit/KafkaIntegrationTest.java
+++ b/src/test/java/info/batey/kafka/unit/KafkaIntegrationTest.java
@@ -16,11 +16,14 @@
 package info.batey.kafka.unit;
 
 import kafka.producer.KeyedMessage;
+import kafka.server.KafkaServerStartable;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
 
@@ -40,7 +43,10 @@ public class KafkaIntegrationTest {
 
     @After
     public void shutdown() throws Exception {
-        assert kafkaUnitServer.broker.serverConfig().logSegmentBytes() == 1024;
+        Field f = kafkaUnitServer.getClass().getDeclaredField("broker");
+        f.setAccessible(true);
+        KafkaServerStartable broker = (KafkaServerStartable) f.get(kafkaUnitServer);
+        assertEquals(1024, broker.serverConfig().logSegmentBytes());
 
         kafkaUnitServer.shutdown();
     }


### PR DESCRIPTION
To ensure users can only access the broker via the public methods, it's been made private.