### PR TITLE
Alternative constructor parsing connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ kafkaUnitServer.startup();
 kafkaUnitServer.shutdown();
 ```
 
+The alternative constructor allows providing connection strings rather than ports, which might be convenient if you want to use existing config without parsing it to extract port numbers:
+
+```java
+KafkaUnit kafkaUnitServer = new KafkaUnit("localhost:5000", "localhost:5001");
+```
+
+It's required that such a connection string consists of only one host:port pair - otherwise an exception will be thrown.
+
 You can then write your own code to interact with Kafka or use the following methods:
 
 ```java

--- a/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnit.java
@@ -62,8 +62,38 @@ public class KafkaUnit {
         this.brokerString = "localhost:" + brokerPort;
     }
 
-    public void startup() {
+    public KafkaUnit(String zkConnectionString, String kafkaConnectionString) {
+        this.zkPort = parseConnectionString(zkConnectionString);;
+        this.brokerPort = parseConnectionString(kafkaConnectionString);
+        this.zookeeperString = "localhost:" + zkPort;
+        this.brokerString = "localhost:" + brokerPort;
+    }
 
+    private int parseConnectionString(String connectionString) {
+        try {
+            String[] hostPorts = connectionString.split(",");
+
+            if (hostPorts.length != 1) {
+                throw new IllegalArgumentException("Only one 'host:port' pair is allowed in connection string");
+            }
+
+            String[] hostPort = hostPorts[0].split(":");
+
+            if (hostPort.length != 2) {
+                throw new IllegalArgumentException("Invalid format of a 'host:port' pair");
+            }
+
+            if (!"localhost".equals(hostPort[0])) {
+                throw new IllegalArgumentException("Only localhost is allowed for KafkaUnit");
+            }
+
+            return Integer.parseInt(hostPort[1]);
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot parse connectionString " + connectionString, e);
+        }
+    }
+
+    public void startup() {
         zookeeper = new Zookeeper(zkPort);
         zookeeper.startup();
 

--- a/src/test/java/info/batey/kafka/unit/KafkaUnitTest.java
+++ b/src/test/java/info/batey/kafka/unit/KafkaUnitTest.java
@@ -1,0 +1,42 @@
+package info.batey.kafka.unit;
+
+
+import org.junit.Test;
+
+public class KafkaUnitTest {
+
+    @Test
+    public void successfullyConstructKafkaUnitFromConnectionStrings() {
+        new KafkaUnit("localhost:2181", "localhost:9092");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void failToConstructKafkaUnitFromZooKeeperConnectionStringWithNonNumericPort() {
+        new KafkaUnit("localhost:abcd", "localhost:9092");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void failToConstructKafkaUnitFromKafkaConnectionStringWithNonNumericPort() {
+        new KafkaUnit("localhost:2181", "localhost:abcd");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void failToConstructKafkaUnitFromZooKeeperConnectionStringWithMultipleHosts() {
+        new KafkaUnit("localhost:2181,localhost:2182", "localhost:9092");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void failToConstructKafkaUnitFromKafkaConnectionStringWithMultipleHosts() {
+        new KafkaUnit("localhost:2181", "localhost:9092,localhost:9093");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void failToConstructKafkaUnitFromInvalidZooKeeperConnectionString() {
+        new KafkaUnit("localhost-2181", "localhost:9092");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void failToConstructKafkaUnitFromInvalidKafkaConnectionString() {
+        new KafkaUnit("localhost:2181", "localhost-9092");
+    }
+}


### PR DESCRIPTION
As I'm mainly using the `host:port` connection strings in my configs (rather than separating host and port using two variables), like these...

```
  kafka.bootstrap.servers = "localhost:9092"
  zookeeper.servers = "localhost:2181"
```

...I found it useful to add a constructor allowing to pass these connection strings to KafkaUnit and extract the port number there, rather than having to parse them every time on my own. It seems to be a popular pattern for Kafka and Zookeeper (and other HA services like Cassandra etc. where you often point to multiple nodes running a service), I thought you may find it useful too.

BTW. tests look a bit messy as I'm testing the same thing for two params separately, but that's what exposed in this class at the moment. I found relaxing the access restriction on parseConnectionString method (to protected) a bit "dirty" and I think that extracting parser to separate class seems to be a bit of an overkill now, but I'm open for suggestions as I don't have a strong opinion on that ;-)