### PR TITLE
Added commons-io to recursively delete Kafka temporary files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ dependencies {
         exclude module: 'slf4j-log4j12'
         exclude module: 'log4j'
     }
+    compile('org.apache.commons:commons-io:1.3.2')
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
 

--- a/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnit.java
@@ -122,7 +122,7 @@ public class KafkaUnit {
                 try {
                     FileUtils.deleteDirectory(logDir);
                 } catch (IOException e) {
-                    LOGGER.warn("Problems deleting temporary directory {}.", logDir.getAbsolutePath(), e);
+                    LOGGER.warn("Problems deleting temporary directory " + logDir.getAbsolutePath(), e);
                 }
             }
         }));

--- a/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnit.java
@@ -31,6 +31,7 @@ import kafka.server.KafkaConfig;
 import kafka.server.KafkaServerStartable;
 import kafka.utils.VerifiableProperties;
 import kafka.utils.ZkUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.security.JaasUtils;
 
@@ -108,13 +109,23 @@ public class KafkaUnit {
         zookeeper = new Zookeeper(zkPort);
         zookeeper.startup();
 
-        File logDir;
+        final File logDir;
         try {
             logDir = Files.createTempDirectory("kafka").toFile();
         } catch (IOException e) {
             throw new RuntimeException("Unable to start Kafka", e);
         }
         logDir.deleteOnExit();
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    FileUtils.deleteDirectory(logDir);
+                } catch (IOException e) {
+                    LOGGER.warn("Problems deleting temporary directory {}.", logDir.getAbsolutePath(), e);
+                }
+            }
+        }));
         kafkaBrokerConfig.setProperty("zookeeper.connect", zookeeperString);
         kafkaBrokerConfig.setProperty("broker.id", "1");
         kafkaBrokerConfig.setProperty("host.name", "localhost");


### PR DESCRIPTION
Fixes #21.
I couldn't figure out how to easily add a unit test, so I only performed functional testing.  I ran my unit test in debug mode and found the temporary directory where Kafka used for persistence, then let the test finish.  Once the test completed, the temporary directory was completely removed.