### PR TITLE
Provide the ability to be able to obtain the key of received messages

### DIFF
--- a/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnit.java
@@ -24,7 +24,6 @@ import kafka.javaapi.consumer.ConsumerConnector;
 import kafka.javaapi.producer.Producer;
 import kafka.message.MessageAndMetadata;
 import kafka.producer.KeyedMessage;
-import kafka.producer.KeyedMessage$;
 import kafka.producer.ProducerConfig;
 import kafka.serializer.StringDecoder;
 import kafka.serializer.StringEncoder;

--- a/src/test/java/info/batey/kafka/unit/KafkaIntegrationTest.java
+++ b/src/test/java/info/batey/kafka/unit/KafkaIntegrationTest.java
@@ -104,6 +104,23 @@ public class KafkaIntegrationTest {
         assertEquals("test", kafkaUnitServer.readMessages(topic, 1).get(0));
     }
 
+    @Test
+    public void  canReadKeyedMessages() throws Exception {
+        //given
+        String testTopic = "TestTopic";
+        kafkaUnitServer.createTopic(testTopic);
+        KeyedMessage<String, String> keyedMessage = new KeyedMessage<>(testTopic, "key", "value");
+
+        //when
+        kafkaUnitServer.sendMessages(keyedMessage);
+
+        KeyedMessage<String, String> receivedMessage = kafkaUnitServer.readKeyedMessages(testTopic, 1).get(0);
+
+        assertEquals("Received message value is incorrect", "value", receivedMessage.message());
+        assertEquals("Received message key is incorrect", "key", receivedMessage.key());
+        assertEquals("Received message topic is incorrect", testTopic, receivedMessage.topic());
+    }
+
     private void assertKafkaServerIsAvailable(KafkaUnit server) throws TimeoutException {
         //given
         String testTopic = "TestTopic";


### PR DESCRIPTION
I believe that it would be useful to have the ability to be able to test that the key of a received message is correct.  I have therefore added a readKeyedMessages method that returns a List of KeyedMessage objects rather than Strings.  The original readMessages method has been kept for backwards compatibility and I have refactored in order to minimise code duplication.