### PR TITLE
Kafka unit rule extensions + prepare for 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ And to read messages:
 List<String> messages = kafkaUnitServer.readMessages(testTopic, 1);
 ```
 
-Only String messages are supported at the moment.
+Only `String` messages are supported at the moment.
 
 Alternatively, you can use `getKafkaConnect()` to manually configure producer and consumer clients like:
 
@@ -98,9 +98,11 @@ public class KafkaUnitIntegrationTest {
 }
 ```
 
-This will start/stop the broker every test, so that particular test can't interfere with the next.
+This will start/stop the broker every test, so that particular test can't interfere with the next. 
+Contrary to `KafkaUnit()` constructor, it does not throw checked `IOException` when socket initialization fails, but wraps it in runtime exception and thus is suitable for use as `@Rule` field in tests.
 
-If you want to start server on specific ports, use `KafkaUnitRule(int, int)` constructor, which accepts ZooKeeper and Kafka broker ports respectively:
+If you want to start server on specific ports, use `KafkaUnitRule(int, int)` constructor, which accepts ZooKeeper and
+ Kafka broker ports respectively (just like `KafkaUnit(int, int)` constructor):
 
 ```java
     @Rule

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The alternative constructor allows providing connection strings rather than port
 KafkaUnit kafkaUnitServer = new KafkaUnit("localhost:5000", "localhost:5001");
 ```
 
-It's required that such a connection string consists of only one `host:port` pair - otherwise an exception will be thrown, and the `host` will be replaced by `localhost`.
+Currently only `localhost` is supported and it's required that the connection string consists of only one `localhost:[port]` pair.
 
 You can then write your own code to interact with Kafka or use the following methods:
 
@@ -101,8 +101,7 @@ public class KafkaUnitIntegrationTest {
 This will start/stop the broker every test, so that particular test can't interfere with the next. 
 Contrary to `KafkaUnit()` constructor, it does not throw checked `IOException` when socket initialization fails, but wraps it in runtime exception and thus is suitable for use as `@Rule` field in tests.
 
-If you want to start server on specific ports, use `KafkaUnitRule(int, int)` constructor, which accepts ZooKeeper and
- Kafka broker ports respectively (just like `KafkaUnit(int, int)` constructor):
+If you want to start server on specific ports, use `KafkaUnitRule(int, int)` or `KafkaUnitRule(String, String)` constructor, which accepts ZooKeeper and Kafka broker ports or connection strings respectively (just like corresponding `KafkaUnit` constructors), e.g.:
 
 ```java
     @Rule

--- a/README.md
+++ b/README.md
@@ -19,18 +19,24 @@ Allows you to start and stop a Kafka broker + ZooKeeper instance for unit testin
 <dependency>
     <groupId>info.batey.kafka</groupId>
     <artifactId>kafka-unit</artifactId>
-    <version>0.5</version>
+    <version>0.6</version>
 </dependency>
 ```
 
 ## Starting manually
 
-To start both a Kafka server and ZooKeeper instance, where the two numbers are the ZooKeeper port + the Kafka broker port.
+To start both a Kafka server and ZooKeeper instance on random ports use following code:
 
 ```java
 KafkaUnit kafkaUnitServer = new KafkaUnit();
 kafkaUnitServer.startup();
 kafkaUnitServer.shutdown();
+```
+
+ZooKeeper and Kafka broker ports can be specified explicitly using second constructor, which takes two `int`s:
+
+```java
+KafkaUnit kafkaUnitServer = new KafkaUnit(5000, 5001);
 ```
 
 The alternative constructor allows providing connection strings rather than ports, which might be convenient if you want to use existing config without parsing it to extract port numbers:
@@ -39,7 +45,7 @@ The alternative constructor allows providing connection strings rather than port
 KafkaUnit kafkaUnitServer = new KafkaUnit("localhost:5000", "localhost:5001");
 ```
 
-It's required that such a connection string consists of only one host:port pair - otherwise an exception will be thrown, and the `host` will be replaced by `localhost`.
+It's required that such a connection string consists of only one `host:port` pair - otherwise an exception will be thrown, and the `host` will be replaced by `localhost`.
 
 You can then write your own code to interact with Kafka or use the following methods:
 
@@ -58,6 +64,7 @@ List<String> messages = kafkaUnitServer.readMessages(testTopic, 1);
 Only String messages are supported at the moment.
 
 Alternatively, you can use `getKafkaConnect()` to manually configure producer and consumer clients like:
+
 ```java
 Properties props = new Properties();
 props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class.getCanonicalName());
@@ -65,18 +72,17 @@ props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.g
 props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaUnitServer.getKafkaConnect());
 
 Producer<Long, String> producer = new KafkaProducer<>(props);
-
 ```
 
 ## Using the JUnit Rule
 
-If you don't want to start/stop the server manually you can use the JUnit rule. E.g
+If you don't want to start/stop the server manually, you can use the JUnit rule, e.g.
 
 ```java
 public class KafkaUnitIntegrationTest {
 
     @Rule
-    public KafkaUnitRule kafkaUnitRule = new KafkaUnitRule(6000, 6001);
+    public KafkaUnitRule kafkaUnitRule = new KafkaUnitRule();
 
     @Test
     public void junitRuleShouldHaveStartedKafka() throws Exception {
@@ -92,7 +98,14 @@ public class KafkaUnitIntegrationTest {
 }
 ```
 
-This will start/stop the broker every test so that one test can't interfere with the next.
+This will start/stop the broker every test, so that particular test can't interfere with the next.
+
+If you want to start server on specific ports, use `KafkaUnitRule(int, int)` constructor, which accepts ZooKeeper and Kafka broker ports respectively:
+
+```java
+    @Rule
+    public KafkaUnitRule kafkaUnitRule = new KafkaUnitRule(5000, 5001);
+```
 
 ## License
 

--- a/src/main/java/info/batey/kafka/unit/KafkaUnitRule.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnitRule.java
@@ -35,6 +35,10 @@ public class KafkaUnitRule extends ExternalResource {
         this.kafkaUnit = new KafkaUnit(zkPort, kafkaPort);
     }
 
+    public KafkaUnitRule(String zkConnectionString, String kafkaConnectionString) {
+        this.kafkaUnit = new KafkaUnit(zkConnectionString, kafkaConnectionString);
+    }
+
     @Override
     protected void before() throws Throwable {
         kafkaUnit.startup();

--- a/src/main/java/info/batey/kafka/unit/KafkaUnitRule.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnitRule.java
@@ -23,8 +23,12 @@ public class KafkaUnitRule extends ExternalResource {
 
     private final KafkaUnit kafkaUnit;
 
-    public KafkaUnitRule() throws IOException {
-        this.kafkaUnit = new KafkaUnit();
+    public KafkaUnitRule() {
+        try {
+            this.kafkaUnit = new KafkaUnit();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public KafkaUnitRule(int zkPort, int kafkaPort) {

--- a/src/test/java/info/batey/kafka/unit/KafkaUnitIntegrationTest.java
+++ b/src/test/java/info/batey/kafka/unit/KafkaUnitIntegrationTest.java
@@ -29,11 +29,23 @@ public class KafkaUnitIntegrationTest {
     @Rule
     public KafkaUnitRule kafkaUnitRule = new KafkaUnitRule(6000, 6001);
 
+    @Rule
+    public KafkaUnitRule kafkaUnitRuleWithEphemeralPorts = new KafkaUnitRule();
+
     @Test
     public void junitRuleShouldHaveStartedKafka() throws Exception {
+        assertKafkaStartsAndSendsMessage(kafkaUnitRule.getKafkaUnit());
+    }
+
+    @Test
+    public void junitRuleShouldHaveStartedKafkaWithEphemeralPorts() throws Exception {
+        assertKafkaStartsAndSendsMessage(kafkaUnitRuleWithEphemeralPorts.getKafkaUnit());
+    }
+
+    public void assertKafkaStartsAndSendsMessage(final KafkaUnit kafkaUnit) throws Exception {
         //given
         String testTopic = "TestTopic";
-        kafkaUnitRule.getKafkaUnit().createTopic(testTopic);
+        kafkaUnit.createTopic(testTopic);
         KeyedMessage<String, String> keyedMessage = new KeyedMessage<>(testTopic, "key", "value");
 
         //when

--- a/src/test/java/info/batey/kafka/unit/KafkaUnitIntegrationTest.java
+++ b/src/test/java/info/batey/kafka/unit/KafkaUnitIntegrationTest.java
@@ -30,11 +30,19 @@ public class KafkaUnitIntegrationTest {
     public KafkaUnitRule kafkaUnitRule = new KafkaUnitRule(6000, 6001);
 
     @Rule
+    public KafkaUnitRule kafkaUnitRuleWithConnectionStrings = new KafkaUnitRule("localhost:5000", "localhost:5001");
+
+    @Rule
     public KafkaUnitRule kafkaUnitRuleWithEphemeralPorts = new KafkaUnitRule();
 
     @Test
     public void junitRuleShouldHaveStartedKafka() throws Exception {
         assertKafkaStartsAndSendsMessage(kafkaUnitRule.getKafkaUnit());
+    }
+
+    @Test
+    public void junitRuleShouldHaveStartedKafkaWithConnectionStrings() throws Exception {
+        assertKafkaStartsAndSendsMessage(kafkaUnitRuleWithConnectionStrings.getKafkaUnit());
     }
 
     @Test


### PR DESCRIPTION
`KafkaUnitRule` constructor without ports (a.k.a. ephemeral ports) defines checked `IOException`, which makes it unusable in simplest case possible, because following does not compile:

    public KafkaUnitRule kafkaUnitRule = new KafkaUnitRule();

I removed this checked exception from constructor's signature and I also added constructor for connection strings to reflect changes in `KafkaUnit`, plus I updated README.md. Code is also ready for releasing 0.6 :)