### PR TITLE
Added pollConsumer method to retrieve all available messages on a topic

### DIFF
--- a/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnit.java
@@ -200,6 +200,15 @@ public class KafkaUnit {
         });
     }
 
+    public List<String> pollMessages(String topicName) throws TimeoutException {
+        return readMessages(topicName, -1, new MessageExtractor<String>() {
+            @Override
+            public String extract(MessageAndMetadata<String, String> messageAndMetadata) {
+                return messageAndMetadata.message();
+            }
+        });
+    }
+
     private <T> List<T> readMessages(String topicName, final int expectedMessages, final MessageExtractor<T> messageExtractor) throws TimeoutException {
         ExecutorService singleThread = Executors.newSingleThreadExecutor();
         Properties consumerProperties = new Properties();
@@ -230,7 +239,7 @@ public class KafkaUnit {
                 } catch (ConsumerTimeoutException e) {
                     // always gets throws reaching the end of the stream
                 }
-                if (messages.size() != expectedMessages) {
+                if (expectedMessages >= 0 && messages.size() != expectedMessages) {
                     throw new ComparisonFailure("Incorrect number of messages returned", Integer.toString(expectedMessages),
                             Integer.toString(messages.size()));
                 }


### PR DESCRIPTION
Currently, `readMessages` takes an `expectedMessages` parameter to verify that the number of messages retrieved were as expected, and throws a `org.junit.ComparisonFailure` when they do not. While this is useful within the scope of unit tests, the exception is thrown from another `Thread` and cannot be suppressed; thus, `readMessages` is unsuitable for larger tests that may require a polling loop. This PR changes `readMessages` so that no check is performed and no exception is thrown if there is a negative `expectedMessages` count; it also provides a `pollMessages(String topicName)` method that is effectively an alias for `readMessages(topicName, -1)`. While this may technically be a breaking API change, the check would fail every time for `expectedMessages` < 0 at present.