### PR TITLE
Maximum amount of Zookeeper connections can be specified externally

### DIFF
--- a/src/main/java/info/batey/kafka/unit/KafkaUnit.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnit.java
@@ -59,20 +59,30 @@ public class KafkaUnit {
     private int brokerPort;
     private Producer<String, String> producer = null;
     private Properties kafkaBrokerConfig = new Properties();
+    private int zkMaxConnections;
 
     public KafkaUnit() throws IOException {
         this(getEphemeralPort(), getEphemeralPort());
     }
 
     public KafkaUnit(int zkPort, int brokerPort) {
+        this(zkPort, brokerPort, 16);
+    }
+    
+    public KafkaUnit(int zkPort, int brokerPort, int zkMaxConnections) {
         this.zkPort = zkPort;
         this.brokerPort = brokerPort;
         this.zookeeperString = "localhost:" + zkPort;
         this.brokerString = "localhost:" + brokerPort;
+        this.zkMaxConnections = zkMaxConnections;
     }
 
     public KafkaUnit(String zkConnectionString, String kafkaConnectionString) {
         this(parseConnectionString(zkConnectionString), parseConnectionString(kafkaConnectionString));
+    }
+    
+    public KafkaUnit(String zkConnectionString, String kafkaConnectionString, int zkMaxConnections) {
+        this(parseConnectionString(zkConnectionString), parseConnectionString(kafkaConnectionString), zkMaxConnections);
     }
 
     private static int parseConnectionString(String connectionString) {
@@ -106,7 +116,7 @@ public class KafkaUnit {
     }
 
     public void startup() {
-        zookeeper = new Zookeeper(zkPort);
+        zookeeper = new Zookeeper(zkPort, zkMaxConnections);
         zookeeper.startup();
 
         final File logDir;

--- a/src/main/java/info/batey/kafka/unit/KafkaUnitRule.java
+++ b/src/main/java/info/batey/kafka/unit/KafkaUnitRule.java
@@ -38,6 +38,14 @@ public class KafkaUnitRule extends ExternalResource {
     public KafkaUnitRule(String zkConnectionString, String kafkaConnectionString) {
         this.kafkaUnit = new KafkaUnit(zkConnectionString, kafkaConnectionString);
     }
+    
+    public KafkaUnitRule(int zkPort, int kafkaPort, int zkMaxConnections) {
+        this.kafkaUnit = new KafkaUnit(zkPort, kafkaPort, zkMaxConnections);
+    }
+
+    public KafkaUnitRule(String zkConnectionString, String kafkaConnectionString, int zkMaxConnections) {
+        this.kafkaUnit = new KafkaUnit(zkConnectionString, kafkaConnectionString, zkMaxConnections);
+    }
 
     @Override
     protected void before() throws Throwable {

--- a/src/main/java/info/batey/kafka/unit/Zookeeper.java
+++ b/src/main/java/info/batey/kafka/unit/Zookeeper.java
@@ -25,11 +25,18 @@ import java.net.InetSocketAddress;
 
 public class Zookeeper {
     private int port;
+    private int maxConnections;
 
     private ServerCnxnFactory factory;
 
     public Zookeeper(int port) {
         this.port = port;
+        this.maxConnections = 16;
+    }
+    
+    public Zookeeper(int port, int maxConnections) {
+        this.port = port;
+        this.maxConnections = maxConnections;
     }
 
     public void startup() {
@@ -50,7 +57,7 @@ public class Zookeeper {
             int tickTime = 500;
             ZooKeeperServer zkServer = new ZooKeeperServer(snapshotDir, logDir, tickTime);
             this.factory = NIOServerCnxnFactory.createFactory();
-            this.factory.configure(new InetSocketAddress("localhost", port), 16);
+            this.factory.configure(new InetSocketAddress("localhost", port), maxConnections);
             factory.startup(zkServer);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();


### PR DESCRIPTION
We faced the problem that the amount of Zookeeper connections allowed via KafkaUnit (16) is too low for our tests. As there was no way to specify this setting externally we created this patch.

Old code continues to work as the default of 16 connections is still in place. An additional constructor was introduced which forwards a custom setting to the connection factory.